### PR TITLE
Task 6

### DIFF
--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -22,21 +22,32 @@ const serverlessConfiguration: AWS = {
       NODE_OPTIONS: '--enable-source-maps --stack-trace-limit=1000',
       REGION: '${env:REGION}',
       IMPORT_SERVICE_BUCKET_NAME: '${env:IMPORT_SERVICE_BUCKET_NAME}',
+      SQS_URL: '${env:SQS_URL}',
+      SQS_ARN: '${env:SQS_ARN}',
     },
-    iamRoleStatements: [
-      {
-        Effect: 'Allow',
-        Action: 's3:ListBucket',
-        Resource:
-          'arn:aws:s3:::${self:provider.environment.IMPORT_SERVICE_BUCKET_NAME}',
+    iam: {
+      role: {
+        statements: [
+          {
+            Effect: 'Allow',
+            Action: 's3:ListBucket',
+            Resource:
+              'arn:aws:s3:::${self:provider.environment.IMPORT_SERVICE_BUCKET_NAME}',
+          },
+          {
+            Effect: 'Allow',
+            Action: 's3:*',
+            Resource:
+              'arn:aws:s3:::${self:provider.environment.IMPORT_SERVICE_BUCKET_NAME}/*',
+          },
+          {
+            Effect: 'Allow',
+            Action: 'sqs:*',
+            Resource: '${self:provider.environment.SQS_ARN}',
+          },
+        ],
       },
-      {
-        Effect: 'Allow',
-        Action: 's3:*',
-        Resource:
-          'arn:aws:s3:::${self:provider.environment.IMPORT_SERVICE_BUCKET_NAME}/*',
-      },
-    ],
+    },
   },
   functions: { importProductsFile, importFileParser },
   package: { individually: true },

--- a/product-service/package.json
+++ b/product-service/package.json
@@ -11,6 +11,7 @@
     "deploy:getProductsList": "sls deploy function -f getProductsList",
     "deploy:getProductsById": "sls deploy function -f getProductsById",
     "deploy:createProduct": "sls deploy function -f createProduct",
+    "deploy:catalogBatchProcess": "sls deploy function -f catalogBatchProcess",
     "invoke:local:getProductsList": "sls invoke local -f getProductsList --path src/functions/getProductsList/mock.json",
     "invoke:local:getProductsById": "sls invoke local -f getProductsById --path src/functions/getProductsById/mock.json",
     "invoke:local:createProduct": "sls invoke local -f createProduct --path src/functions/createProduct/mock.json",

--- a/product-service/serverless.ts
+++ b/product-service/serverless.ts
@@ -2,6 +2,7 @@ import type { AWS } from '@serverless/typescript';
 import getProductsList from 'functions/getProductsList';
 import getProductsById from 'functions/getProductsById';
 import createProduct from 'functions/createProduct';
+import catalogBatchProcess from 'functions/catalogBatchProcess';
 
 const serverlessConfiguration: AWS = {
   service: 'product-service',
@@ -26,17 +27,84 @@ const serverlessConfiguration: AWS = {
       NODE_OPTIONS: '--enable-source-maps --stack-trace-limit=1000',
       PRODUCTS_TABLE_NAME: '${env:PRODUCTS_TABLE_NAME}',
       STOCKS_TABLE_NAME: '${env:STOCKS_TABLE_NAME}',
-    },
-    iamRoleStatements: [
-      {
-        Effect: 'Allow',
-        Action: 'dynamodb:*',
-        Resource: 'arn:aws:dynamodb:${self:provider.region}:*:table/*',
+      SQS_URL: {
+        Ref: 'SQSQueue',
       },
-    ],
+      SNS_ARN: {
+        Ref: 'SNSTopic',
+      },
+      CREATE_PRODUCT_TOPIC_EMAIL: '${env:CREATE_PRODUCT_TOPIC_EMAIL}',
+      CREATE_UNIQUE_PRODUCT_TOPIC_EMAIL:
+        '${env:CREATE_UNIQUE_PRODUCT_TOPIC_EMAIL}',
+    },
+    iam: {
+      role: {
+        statements: [
+          {
+            Effect: 'Allow',
+            Action: 'dynamodb:*',
+            Resource: 'arn:aws:dynamodb:${self:provider.region}:*:table/*',
+          },
+          {
+            Effect: 'Allow',
+            Action: 'sqs:*',
+            Resource: { 'Fn::GetAtt': ['SQSQueue', 'Arn'] },
+          },
+          {
+            Effect: 'Allow',
+            Action: 'sns:*',
+            Resource: { Ref: 'SNSTopic' },
+          },
+        ],
+      },
+    },
   },
-
-  functions: { getProductsList, getProductsById, createProduct },
+  resources: {
+    Resources: {
+      SQSQueue: {
+        Type: 'AWS::SQS::Queue',
+        Properties: {
+          QueueName: 'catalogItemsQueue',
+        },
+      },
+      SNSTopic: {
+        Type: 'AWS::SNS::Topic',
+        Properties: {
+          TopicName: 'createProductTopic',
+        },
+      },
+      SNSSubscription: {
+        Type: 'AWS::SNS::Subscription',
+        Properties: {
+          Endpoint: '${self:provider.environment.CREATE_PRODUCT_TOPIC_EMAIL}',
+          Protocol: 'email',
+          TopicArn: {
+            Ref: 'SNSTopic',
+          },
+        },
+      },
+      SNSSubscriptionForUniqueProducts: {
+        Type: 'AWS::SNS::Subscription',
+        Properties: {
+          Endpoint:
+            '${self:provider.environment.CREATE_UNIQUE_PRODUCT_TOPIC_EMAIL}',
+          Protocol: 'email',
+          TopicArn: {
+            Ref: 'SNSTopic',
+          },
+          FilterPolicy: {
+            price: [{ numeric: ['>=', 100] }],
+          },
+        },
+      },
+    },
+  },
+  functions: {
+    getProductsList,
+    getProductsById,
+    createProduct,
+    catalogBatchProcess,
+  },
   package: {
     individually: true,
     excludeDevDependencies: true,

--- a/product-service/src/functions/catalogBatchProcess/handler.test.ts
+++ b/product-service/src/functions/catalogBatchProcess/handler.test.ts
@@ -1,0 +1,112 @@
+import { catalogBatchProcess } from './handler';
+import { addProduct } from '../handlers';
+
+jest.mock('../handlers', () => ({
+  addProduct: jest.fn(),
+}));
+
+const mockSNSPublish = jest.fn().mockReturnValue({ promise: jest.fn() });
+jest.mock('aws-sdk', () => ({
+  SNS: jest.fn().mockImplementation(function () {
+    this.publish = mockSNSPublish;
+  }),
+}));
+
+describe('catalogBatchProcess', () => {
+  const baseEvent = {
+    Records: [
+      {
+        messageId: undefined,
+        receiptHandle: undefined,
+        body: JSON.stringify({
+          title: 'Test 1',
+          price: '299',
+          description: 'Test 1 description',
+          image: 'https://api.lorem.space/image/shoes?w=640&h=480&r=1286',
+          count: '17',
+        }),
+        attributes: undefined,
+        messageAttributes: undefined,
+        md5OfBody: undefined,
+        eventSource: undefined,
+        eventSourceARN: undefined,
+        awsRegion: undefined,
+      },
+      {
+        messageId: undefined,
+        receiptHandle: undefined,
+        body: JSON.stringify({
+          title: 'Test 2',
+          price: '99',
+          description: 'Test 2 description',
+          image: 'https://api.lorem.space/image/shoes?w=640&h=480&r=1235',
+          count: '4',
+        }),
+        attributes: undefined,
+        messageAttributes: undefined,
+        md5OfBody: undefined,
+        eventSource: undefined,
+        eventSourceARN: undefined,
+        awsRegion: undefined,
+      },
+    ],
+  };
+
+  it('should create products and publish message', async () => {
+    (addProduct as jest.Mock).mockReturnValue(Promise.resolve());
+    await catalogBatchProcess(baseEvent);
+    expect(addProduct).toHaveBeenCalledTimes(2);
+    expect((addProduct as jest.Mock).mock.calls[0][0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          description: 'Test 1 description',
+          image: 'https://api.lorem.space/image/shoes?w=640&h=480&r=1286',
+          price: 299,
+          title: 'Test 1',
+        }),
+        expect.objectContaining({ count: 17 }),
+      ])
+    );
+    expect((addProduct as jest.Mock).mock.calls[1][0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          description: 'Test 2 description',
+          image: 'https://api.lorem.space/image/shoes?w=640&h=480&r=1235',
+          price: 99,
+          title: 'Test 2',
+        }),
+        expect.objectContaining({ count: 4 }),
+      ])
+    );
+
+    expect(mockSNSPublish).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(mockSNSPublish.mock.calls[0][0].Message)).toEqual([
+      {
+        count: '17',
+        description: 'Test 1 description',
+        image: 'https://api.lorem.space/image/shoes?w=640&h=480&r=1286',
+        price: '299',
+        title: 'Test 1',
+      },
+      {
+        count: '4',
+        description: 'Test 2 description',
+        image: 'https://api.lorem.space/image/shoes?w=640&h=480&r=1235',
+        price: '99',
+        title: 'Test 2',
+      },
+    ]);
+  });
+
+  it('should not publish message if products not created', async () => {
+    (addProduct as jest.Mock).mockReset();
+    mockSNSPublish.mockReset();
+    (addProduct as jest.Mock).mockRejectedValue(
+      Promise.reject('TransactionCanceledException: Transaction cancelled')
+    );
+    await catalogBatchProcess(baseEvent);
+
+    expect(addProduct).toHaveBeenCalledTimes(2);
+    expect(mockSNSPublish).toHaveBeenCalledTimes(0);
+  });
+});

--- a/product-service/src/functions/catalogBatchProcess/handler.ts
+++ b/product-service/src/functions/catalogBatchProcess/handler.ts
@@ -1,0 +1,59 @@
+import { SQSEvent } from 'aws-lambda';
+import { SNS } from 'aws-sdk';
+import { v4 as uuidv4 } from 'uuid';
+import { addProduct } from 'functions/handlers';
+import { asyncPipe, mapProductPayload } from 'functions/helpers';
+import { ProductPayload } from 'functions/types';
+
+export const catalogBatchProcess = async (event: SQSEvent): Promise<void> => {
+  try {
+    const sns = new SNS({ region: process.env.REGION });
+    const products: ProductPayload[] = event.Records.map(({ body }) =>
+      JSON.parse(body)
+    );
+    const promiseArr = [];
+
+    products.forEach((product) => {
+      const res = asyncPipe(
+        mapProductPayload,
+        addProduct
+      )({ ...product, id: uuidv4() });
+
+      promiseArr.push(res);
+    });
+
+    await Promise.all(promiseArr);
+
+    try {
+      await Promise.all(
+        products.map((product) => {
+          sns
+            .publish({
+              Subject: 'Products have been created',
+              Message: JSON.stringify(product),
+              TopicArn: process.env.SNS_ARN,
+              MessageAttributes: {
+                price: {
+                  DataType: 'Number',
+                  StringValue: `${product.price}`,
+                },
+              },
+            })
+            .promise();
+        })
+      );
+
+      console.log(
+        `SNS: ${
+          products.length > 1
+            ? products.length + ' products have been created'
+            : products.length + ' product has been created'
+        }`
+      );
+    } catch (err) {
+      console.log(`SNS error: ${err}`);
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/product-service/src/functions/catalogBatchProcess/index.ts
+++ b/product-service/src/functions/catalogBatchProcess/index.ts
@@ -1,0 +1,13 @@
+import { handlerPath } from 'libs/handler-resolver';
+
+export default {
+  handler: `${handlerPath(__dirname)}/handler.catalogBatchProcess`,
+  events: [
+    {
+      sqs: {
+        arn: { 'Fn::GetAtt': ['SQSQueue', 'Arn'] },
+        batchSize: 5,
+      },
+    },
+  ],
+};

--- a/product-service/src/functions/helpers/product.mapper.ts
+++ b/product-service/src/functions/helpers/product.mapper.ts
@@ -33,13 +33,13 @@ export const mapProductPayload = (
     {
       id: product.id,
       title: product.title,
-      price: product.price,
+      price: Number(product.price),
       description: product.description,
       image: product.image,
     },
     {
       product_id: product.id,
-      count: product.count,
+      count: Number(product.count),
     },
   ];
 };

--- a/product-service/src/functions/index.ts
+++ b/product-service/src/functions/index.ts
@@ -1,3 +1,4 @@
 export { default as getProductsList } from './getProductsList';
 export { default as getProductsById } from './getProductsById';
 export { default as createProduct } from './createProduct';
+export { default as catalogBatchProcess } from './catalogBatchProcess';


### PR DESCRIPTION
What was done:
**Task 6.1**
- [x] Create a lambda function called catalogBatchProcess under the same Serverless config file (i.e. serverless.yaml) of the Product Service which will be triggered by an SQS event. [Link to СatalogBatchProcess Lambda](https://github.com/tanyak1601/aws-course-be/blob/task-6/product-service/src/functions/catalogBatchProcess/handler.ts)
- [x] Create an SQS queue called catalogItemsQueue, in the resources section of the same serverless.yml file. [Link to serverless.ts](https://github.com/tanyak1601/aws-course-be/blob/task-6/product-service/serverless.ts)
- [x] Configure the SQS to trigger lambda catalogBatchProcess with 5 messages at once via batchSize property.
- [x] The lambda function should iterate over all SQS messages and create corresponding products in the products table.

**Task 6.2**
- [x] Update the importFileParser lambda function in the Import Service to send each CSV record into SQS. [Link to importFileParser Lambda](https://github.com/tanyak1601/aws-course-be/blob/task-6/import-service/src/functions/importFileParser/handler.ts)
- [x] It should no longer log entries from the readable stream to CloudWatch.

**Task 6.3**
- [x] Create an SNS topic createProductTopic and email subscription in the resources section in serverless.yml of the Product Service.  [Link to serverless.ts](https://github.com/tanyak1601/aws-course-be/blob/task-6/product-service/serverless.ts)
- [x] Create a subscription for this SNS topic with an email endpoint type with your own email in there.
- [x] Update the catalogBatchProcess lambda function in the Product Service to send an event to the SNS topic once it creates products. [Link to СatalogBatchProcess Lambda]

**Additional (optional) tasks**
- [x] +15 - catalogBatchProcess lambda is covered by unit tests [Link to test file](https://github.com/tanyak1601/aws-course-be/blob/task-6/product-service/src/functions/catalogBatchProcess/handler.test.ts)
- [x] +15 - set a Filter Policy for SNS createProductTopic in serverless.yml and create an additional email subscription to distribute messages to different emails depending on the filter for any product attribute
![Screenshot 2023-03-19 at 1 42 44 PM](https://user-images.githubusercontent.com/50367908/226170320-791a3430-97d4-4271-afeb-2a5d2dc2957f.png)
![Screenshot 2023-03-19 at 1 43 02 PM](https://user-images.githubusercontent.com/50367908/226170328-b54ed9ea-55ae-4f82-b6c2-1d667ab36fae.png)
